### PR TITLE
migrate Dockerfiles from npm to pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN pnpm install
 
 COPY . .
 
-CMD ["pnpm", "run", "start:dev"]
+CMD ["pnpm dev", "run", "start:dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM node:20-alpine
 
+RUN npm install -g pnpm
+
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+
+RUN pnpm install
 
 COPY . .
 
-CMD ["npm", "run", "start:dev"]
+CMD ["pnpm", "run", "start:dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Dockerfile.dev
 FROM node:20-alpine
 
-# 全局装 pnpm
 RUN npm install -g pnpm
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
+# Dockerfile.dev
 FROM node:20-alpine
 
+# 全局装 pnpm
 RUN npm install -g pnpm
 
 WORKDIR /app
 
-COPY package*.json ./
-
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install
 
-COPY . .
-
-CMD ["pnpm", "run", "start:dev"]
+EXPOSE 4000
+CMD ["pnpm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN pnpm install
 
 COPY . .
 
-CMD ["pnpm dev", "run", "start:dev"]
+CMD ["pnpm", "run", "start:dev"]

--- a/Dockerfile.uat
+++ b/Dockerfile.uat
@@ -1,12 +1,15 @@
 FROM node:20-alpine
 
+# Enable pnpm via Corepack
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
 WORKDIR /app
 
 COPY dist ./dist
 COPY package.json ./
-COPY package-lock.json ./
+COPY pnpm-lock.yaml ./
 
-RUN npm install --omit=dev
+RUN pnpm install --prod
 
 EXPOSE 4000
 CMD ["node", "dist/main"]

--- a/Dockerfile.uat
+++ b/Dockerfile.uat
@@ -8,7 +8,7 @@ COPY dist ./dist
 COPY package.json ./
 COPY pnpm-lock.yaml ./
 
-RUN pnpm install --prod
+RUN pnpm install
 
 EXPOSE 4000
 CMD ["node", "dist/main"]

--- a/Dockerfile.uat
+++ b/Dockerfile.uat
@@ -1,7 +1,6 @@
 FROM node:20-alpine
 
-# Enable pnpm via Corepack
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ dispatchai-backend/
 
 
   ```bash
-  curl http://localhost:4000/health
+  curl http://localhost:4000/api/health
   ```
 
   Expected response:
@@ -101,7 +101,7 @@ dispatchai-backend/
 
 - `GET /health/db` - Database connection check
   ```bash
-  curl http://localhost:4000/health/db
+  curl http://localhost:4000/api/health/db
   ```
   Expected response:
   ```json
@@ -194,7 +194,7 @@ You can use tools like Postman, cURL, or REST client extensions to test the API 
 Example with cURL:
 
 ```bash
-curl http://localhost:4000/health
+curl http://localhost:4000/api/health
 ```
 
 ## Troubleshooting
@@ -225,4 +225,4 @@ curl http://localhost:4000/health
 
 ## Swagger
 
-Enter http://localhost:4000/api-docs to view the swagger documentation
+Enter http://localhost:4000/api/docs to view the swagger documentation

--- a/README.md
+++ b/README.md
@@ -53,11 +53,7 @@ dispatchai-backend/
 
    ```bash
    # Development mode with hot-reload
-   pnpm run build
    pnpm run dev
-
-   # Debug mode
-   pnpm run start:debug
 
    # Production build and run
    pnpm run build
@@ -193,15 +189,18 @@ To create a new feature module:
 ```bash
 # Run all tests
 pnpm test
+```
 
-# Run all e2e tests
-pnpm run test:e2e
+### Type Checking
 
-# Run tests with watch mode
-pnpm run test:watch
+```bash
+pnpm run type-check
+```
 
-# Generate test coverage report
-pnpm run test:cov
+### Linting
+
+```bash
+pnpm run lint
 ```
 
 ### API Tests
@@ -232,16 +231,6 @@ curl http://localhost:3000/health
 3. **Docker issues**:
    - If changes aren't reflecting, rebuild with `docker-compose up --build -d`
    - Check logs with `docker-compose logs -f api`
-
-### Debugging
-
-1. Use NestJS debug mode:
-
-   ```bash
-   pnpm run start:debug
-   ```
-
-2. Attach your IDE debugger to the process
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ dispatchai-backend/
 1. Install dependencies:
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 2. Start a local MongoDB instance:
@@ -53,15 +53,15 @@ dispatchai-backend/
 
    ```bash
    # Development mode with hot-reload
-   npm run build
-   npm run start:dev
+   pnpm run build
+   pnpm run dev
 
    # Debug mode
-   npm run start:debug
+   pnpm run start:debug
 
    # Production build and run
-   npm run build
-   npm run start
+   pnpm run build
+   pnpm run start
    ```
 
 ### Docker Setup
@@ -192,13 +192,16 @@ To create a new feature module:
 
 ```bash
 # Run all tests
-npm test
+pnpm test
+
+# Run all e2e tests
+pnpm run test:e2e
 
 # Run tests with watch mode
-npm run test:watch
+pnpm run test:watch
 
 # Generate test coverage report
-npm run test:cov
+pnpm run test:cov
 ```
 
 ### API Tests
@@ -235,7 +238,7 @@ curl http://localhost:3000/health
 1. Use NestJS debug mode:
 
    ```bash
-   npm run start:debug
+   pnpm run start:debug
    ```
 
 2. Attach your IDE debugger to the process

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dispatchai-backend/
    pnpm run build
    ```
 
-### Docker Setup
+### Docker Setup (DEV)
 
 1. Stop containers:
 
@@ -65,11 +65,23 @@ dispatchai-backend/
    docker compose logs -f api
    ```
 
-## API Endpoints
+### Docker Setup (UAT)
+
+1. Stop containers:
+
+   ```bash
+   docker compose down
+   ```
+
+2. Rebuild containers after code changes:
+   ```bash
+   docker compose -f docker-compose.uat.yml up -d --build
+   ```
 
 ### Health Checks
 
 - `GET /health` - Basic health check
+
 
   ```bash
   curl http://localhost:4000/health

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ dispatchai-backend/
 2. Run the application:
 
    ```bash
-   # Build and run
    pnpm run build
    ```
 
@@ -54,13 +53,14 @@ dispatchai-backend/
    docker compose down
    ```
 
-2. Rebuild containers after code changes:
+2. Build container & Rebuild containers after code changes:
 
    ```bash
    docker compose up -d --build 
    ```
 
 3. View logs:
+
    ```bash
    docker compose logs -f api
    ```
@@ -73,7 +73,8 @@ dispatchai-backend/
    docker compose down
    ```
 
-2. Rebuild containers after code changes:
+2. Build container & Rebuild containers after code changes:
+
    ```bash
    docker compose -f docker-compose.uat.yml up -d --build
    ```
@@ -164,11 +165,14 @@ To create a new feature module:
 
 ## Testing
 
-### Unit Tests
-
 ```bash
 # Run all tests
 pnpm test
+```
+
+```bash
+# Run test file
+pnpm test path/to/your/test_file.ts
 ```
 
 ### Type Checking
@@ -221,4 +225,4 @@ curl http://localhost:4000/health
 
 ## Swagger
 
-Enter http://localhost:3000/api-docs to view the swagger documentation
+Enter http://localhost:4000/api-docs to view the swagger documentation

--- a/README.md
+++ b/README.md
@@ -39,50 +39,30 @@ dispatchai-backend/
    pnpm install
    ```
 
-2. Start a local MongoDB instance:
+2. Run the application:
 
    ```bash
-   # Option 1: Using Docker
-   docker run -p 27017:27017 mongo:latest
-
-   # Option 2: Local MongoDB installation
-   # Start your local MongoDB service
-   ```
-
-3. Run the application:
-
-   ```bash
-   # Development mode with hot-reload
-   pnpm run dev
-
-   # Production build and run
+   # Build and run
    pnpm run build
-   pnpm run start
    ```
 
 ### Docker Setup
 
-1. Build and start the containers:
+1. Stop containers:
 
    ```bash
-   docker-compose up -d
+   docker compose down
    ```
 
-2. Stop containers:
+2. Rebuild containers after code changes:
 
    ```bash
-   docker-compose down
+   docker compose up -d --build 
    ```
 
-3. Rebuild containers after code changes:
-
+3. View logs:
    ```bash
-   docker-compose up --build -d
-   ```
-
-4. View logs:
-   ```bash
-   docker-compose logs -f api
+   docker compose logs -f api
    ```
 
 ## API Endpoints
@@ -92,7 +72,7 @@ dispatchai-backend/
 - `GET /health` - Basic health check
 
   ```bash
-  curl http://localhost:3000/health
+  curl http://localhost:4000/health
   ```
 
   Expected response:
@@ -108,7 +88,7 @@ dispatchai-backend/
 
 - `GET /health/db` - Database connection check
   ```bash
-  curl http://localhost:3000/health/db
+  curl http://localhost:4000/health/db
   ```
   Expected response:
   ```json
@@ -121,18 +101,6 @@ dispatchai-backend/
   ```
 
 ## Configuration
-
-### Environment Variables
-
-Create a `.env` file in the root directory with the following variables:
-
-```
-NODE_ENV=development
-PORT=3000
-MONGODB_URI=mongodb://localhost:27017/dispatchai
-```
-
-When using Docker Compose, these environment variables are defined in the docker-compose.yml file.
 
 ### Path Aliases
 
@@ -210,7 +178,7 @@ You can use tools like Postman, cURL, or REST client extensions to test the API 
 Example with cURL:
 
 ```bash
-curl http://localhost:3000/health
+curl http://localhost:4000/health
 ```
 
 ## Troubleshooting
@@ -229,8 +197,8 @@ curl http://localhost:3000/health
    - Make sure the module is imported in app.module.ts
 
 3. **Docker issues**:
-   - If changes aren't reflecting, rebuild with `docker-compose up --build -d`
-   - Check logs with `docker-compose logs -f api`
+   - If changes aren't reflecting, rebuild with `docker compose up --build -d`
+   - Check logs with `docker compose logs -f api`
 
 ## Next Steps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   api:
     build:
@@ -19,6 +17,9 @@ services:
       - SHOW_ERROR_MESSAGE=true
     networks:
       - dispatchai-network
+    volumes:
+      - ./:/app
+      - /app/node_modules
 
   mongodb:
     image: mongo:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   api:
     build:
       context: .
-      dockerfile: Dockerfile.uat  # ✅ 使用运行时 Dockerfile
+      dockerfile: Dockerfile
     container_name: dispatchai-api
     restart: always
     ports:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "dev": "nest start --watch",
     "build": "nest build",
     "start": "node dist/main",
-    "start:dev": "nest start --debug --watch",
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:e2e": "jest --config ./test/jest-e2e.json",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev": "nest start --watch",
     "build": "nest build",
     "start": "node dist/main",
+    "start:dev": "nest start --debug --watch",
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:e2e": "jest --config ./test/jest-e2e.json",


### PR DESCRIPTION
Switched the package manager in `Dockerfile` and `Dockerfile.uat` from npm to pnpm. 
- Updated installation steps `pnpm`.
- Updated `README.md`.
- Tested locally in Docker; container was built and started successfully.