### PR TITLE
Bugfix/add interface to transcript and transcript_chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dispatchai-backend/
 2. Run the application:
 
    ```bash
-   pnpm run build
+   pnpm build
    ```
 
 ### Docker Setup (DEV)

--- a/src/common/constants/transcript_chunk.constant.ts
+++ b/src/common/constants/transcript_chunk.constant.ts
@@ -1,0 +1,6 @@
+export type SpeakerType = 'AI' | 'User';
+
+export const SPEAKER_TYPE = {
+  AI: 'AI',
+  USER: 'User',
+} as const;

--- a/src/common/interfaces/transcript.d.ts
+++ b/src/common/interfaces/transcript.d.ts
@@ -1,0 +1,8 @@
+import { Types } from 'mongoose';
+
+export interface ITranscript {
+  calllogid: Types.ObjectId;
+  summary: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/src/common/interfaces/transcript.d.ts
+++ b/src/common/interfaces/transcript.d.ts
@@ -1,4 +1,4 @@
-import { Types } from 'mongoose';
+import type { Types } from 'mongoose';
 
 export interface ITranscript {
   calllogid: Types.ObjectId;

--- a/src/common/interfaces/transcript_chuck.d.ts
+++ b/src/common/interfaces/transcript_chuck.d.ts
@@ -1,0 +1,12 @@
+import { Types } from 'mongoose';
+import { SpeakerType } from '../constants/transcript_chunk.constant';
+
+export interface ITranscriptChunk {
+  transcriptId: Types.ObjectId;
+  speakerType: SpeakerType;
+  text: string;
+  startAt: Date;
+  endAt: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/src/common/interfaces/transcript_chuck.d.ts
+++ b/src/common/interfaces/transcript_chuck.d.ts
@@ -1,5 +1,6 @@
-import { Types } from 'mongoose';
-import { SpeakerType } from '../constants/transcript_chunk.constant';
+import type { Types } from 'mongoose';
+
+import type { SpeakerType } from '../constants/transcript_chunk.constant';
 
 export interface ITranscriptChunk {
   transcriptId: Types.ObjectId;

--- a/src/modules/transcript/transcript.controller.ts
+++ b/src/modules/transcript/transcript.controller.ts
@@ -10,6 +10,7 @@ import {
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 
 import { ITranscript } from '@/common/interfaces/transcript';
+
 import { CreateTranscriptDto, UpdateTranscriptDto } from './dto';
 import { Transcript } from './schema/transcript.schema';
 import { TranscriptService } from './transcript.service';

--- a/src/modules/transcript/transcript.controller.ts
+++ b/src/modules/transcript/transcript.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 
+import { ITranscript } from '@/common/interfaces/transcript';
 import { CreateTranscriptDto, UpdateTranscriptDto } from './dto';
 import { Transcript } from './schema/transcript.schema';
 import { TranscriptService } from './transcript.service';
@@ -20,13 +21,13 @@ export class TranscriptController {
 
   @Post()
   @ApiOkResponse({ type: Transcript })
-  create(@Body() dto: CreateTranscriptDto): Promise<Transcript> {
+  create(@Body() dto: CreateTranscriptDto): Promise<ITranscript> {
     return this.transcriptService.create(dto);
   }
 
   @Get('calllog/:calllogid')
   @ApiOkResponse({ type: [Transcript] })
-  findByCalllog(@Param('calllogid') calllogid: string): Promise<Transcript[]> {
+  findByCalllog(@Param('calllogid') calllogid: string): Promise<ITranscript[]> {
     return this.transcriptService.findByCalllogId(calllogid);
   }
 
@@ -35,13 +36,13 @@ export class TranscriptController {
   update(
     @Param('id') id: string,
     @Body() dto: UpdateTranscriptDto,
-  ): Promise<Transcript> {
+  ): Promise<ITranscript> {
     return this.transcriptService.update(id, dto);
   }
 
   @Delete(':id')
   @ApiOkResponse({ type: Transcript })
-  delete(@Param('id') id: string): Promise<Transcript> {
+  delete(@Param('id') id: string): Promise<ITranscript> {
     return this.transcriptService.delete(id);
   }
 }

--- a/src/modules/transcript/transcript.controller.ts
+++ b/src/modules/transcript/transcript.controller.ts
@@ -15,8 +15,8 @@ import { CreateTranscriptDto, UpdateTranscriptDto } from './dto';
 import { Transcript } from './schema/transcript.schema';
 import { TranscriptService } from './transcript.service';
 
-@ApiTags('Transcripts')
-@Controller('transcripts')
+@ApiTags('Transcript')
+@Controller('transcript')
 export class TranscriptController {
   constructor(private readonly transcriptService: TranscriptService) {}
 
@@ -24,6 +24,12 @@ export class TranscriptController {
   @ApiOkResponse({ type: Transcript })
   create(@Body() dto: CreateTranscriptDto): Promise<ITranscript> {
     return this.transcriptService.create(dto);
+  }
+
+  @Get()
+  @ApiOkResponse({ type: [Transcript] })
+  findAll(): Promise<ITranscript[]> {
+    return this.transcriptService.findAll();
   }
 
   @Get('calllog/:calllogid')

--- a/src/modules/transcript/transcript.service.ts
+++ b/src/modules/transcript/transcript.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 

--- a/src/modules/transcript/transcript.service.ts
+++ b/src/modules/transcript/transcript.service.ts
@@ -36,6 +36,10 @@ export class TranscriptService {
     return this.transcriptModel.create(dto);
   }
 
+  async findAll(): Promise<Transcript[]> {
+    return this.transcriptModel.find().exec();
+  }
+
   async findByCalllogId(calllogid: string): Promise<Transcript[]> {
     return this.transcriptModel.find({ calllogid }).exec();
   }

--- a/src/modules/transcript_chunk/transcript_chunk.controller.ts
+++ b/src/modules/transcript_chunk/transcript_chunk.controller.ts
@@ -22,8 +22,8 @@ import { UpdateTranscriptChunkDto } from './dto/update-transcript-chunk.dto';
 import { TranscriptChunk } from './schema/transcript_chunk.schema';
 import { TranscriptChunkService } from './transcript_chunk.service';
 
-@ApiTags('TranscriptChunks')
-@Controller('transcript-chunks')
+@ApiTags('TranscriptChunk')
+@Controller('transcript-chunk')
 export class TranscriptChunkController {
   constructor(private readonly chunkService: TranscriptChunkService) {}
 
@@ -34,13 +34,13 @@ export class TranscriptChunkController {
     return this.chunkService.create(dto);
   }
 
-  @Get(':id/chunks')
+  @Get(':transcriptId/chunk')
   @ApiOkResponse({ type: [TranscriptChunk] })
-  findAll(@Param('id') transcriptId: string): Promise<ITranscriptChunk[]> {
+  findAll(@Param('transcriptId') transcriptId: string): Promise<ITranscriptChunk[]> {
     return this.chunkService.findAll(transcriptId);
   }
 
-  @Get(':transcriptId/chunks/:id')
+  @Get(':transcriptId/chunk/:id')
   @ApiOkResponse({ type: TranscriptChunk })
   @ApiNotFoundResponse({ description: 'Transcript chunk not found' })
   findOne(
@@ -50,7 +50,7 @@ export class TranscriptChunkController {
     return this.chunkService.findOne(id);
   }
 
-  @Patch(':transcriptId/chunks/:id')
+  @Patch(':transcriptId/chunk/:id')
   @ApiOkResponse({ type: TranscriptChunk })
   @ApiNotFoundResponse({ description: 'Transcript chunk not found' })
   update(

--- a/src/modules/transcript_chunk/transcript_chunk.controller.ts
+++ b/src/modules/transcript_chunk/transcript_chunk.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/swagger';
 
 import { ITranscriptChunk } from '@/common/interfaces/transcript_chuck';
+
 import { CreateTranscriptChunkDto } from './dto/create-transcript-chunk.dto';
 import { UpdateTranscriptChunkDto } from './dto/update-transcript-chunk.dto';
 import { TranscriptChunk } from './schema/transcript_chunk.schema';
@@ -35,9 +36,7 @@ export class TranscriptChunkController {
 
   @Get(':id/chunks')
   @ApiOkResponse({ type: [TranscriptChunk] })
-  findAll(
-    @Param('id') transcriptId: string,
-  ): Promise<ITranscriptChunk[]> {
+  findAll(@Param('id') transcriptId: string): Promise<ITranscriptChunk[]> {
     return this.chunkService.findAll(transcriptId);
   }
 

--- a/src/modules/transcript_chunk/transcript_chunk.controller.ts
+++ b/src/modules/transcript_chunk/transcript_chunk.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import { ITranscriptChunk } from '@/common/interfaces/transcript_chuck';
 import { CreateTranscriptChunkDto } from './dto/create-transcript-chunk.dto';
 import { UpdateTranscriptChunkDto } from './dto/update-transcript-chunk.dto';
 import { TranscriptChunk } from './schema/transcript_chunk.schema';
@@ -28,7 +29,7 @@ export class TranscriptChunkController {
   @Post()
   @ApiCreatedResponse({ type: TranscriptChunk })
   @ApiBadRequestResponse({ description: 'Invalid input or time overlap' })
-  create(@Body() dto: CreateTranscriptChunkDto): Promise<TranscriptChunk> {
+  create(@Body() dto: CreateTranscriptChunkDto): Promise<ITranscriptChunk> {
     return this.chunkService.create(dto);
   }
 
@@ -36,7 +37,7 @@ export class TranscriptChunkController {
   @ApiOkResponse({ type: [TranscriptChunk] })
   findAll(
     @Param('id') transcriptId: string,
-  ): Promise<TranscriptChunk[]> {
+  ): Promise<ITranscriptChunk[]> {
     return this.chunkService.findAll(transcriptId);
   }
 
@@ -46,7 +47,7 @@ export class TranscriptChunkController {
   findOne(
     @Param('transcriptId') transcriptId: string,
     @Param('id') id: string,
-  ): Promise<TranscriptChunk> {
+  ): Promise<ITranscriptChunk> {
     return this.chunkService.findOne(id);
   }
 
@@ -57,7 +58,7 @@ export class TranscriptChunkController {
     @Param('transcriptId') transcriptId: string,
     @Param('id') id: string,
     @Body() dto: UpdateTranscriptChunkDto,
-  ): Promise<TranscriptChunk> {
+  ): Promise<ITranscriptChunk> {
     return this.chunkService.update(id, dto);
   }
 
@@ -67,14 +68,14 @@ export class TranscriptChunkController {
   sanitizedUpdate(
     @Param('id') id: string,
     @Body() dto: UpdateTranscriptChunkDto,
-  ): Promise<TranscriptChunk> {
+  ): Promise<ITranscriptChunk> {
     return this.chunkService.update(id, dto);
   }
 
   @Delete('chunk/:id')
   @ApiOkResponse({ type: TranscriptChunk })
   @ApiNotFoundResponse({ description: 'Transcript chunk not found' })
-  delete(@Param('id') id: string): Promise<TranscriptChunk> {
+  delete(@Param('id') id: string): Promise<ITranscriptChunk> {
     return this.chunkService.delete(id);
   }
 }

--- a/src/modules/transcript_chunk/transcript_chunk.controller.ts
+++ b/src/modules/transcript_chunk/transcript_chunk.controller.ts
@@ -34,6 +34,12 @@ export class TranscriptChunkController {
     return this.chunkService.create(dto);
   }
 
+  @Get()
+  @ApiOkResponse({ type: [TranscriptChunk] })
+  findAllChunks(): Promise<ITranscriptChunk[]> {
+    return this.chunkService.findAllChunks();
+  }
+
   @Get(':transcriptId/chunk')
   @ApiOkResponse({ type: [TranscriptChunk] })
   findAll(@Param('transcriptId') transcriptId: string): Promise<ITranscriptChunk[]> {

--- a/src/modules/transcript_chunk/transcript_chunk.controller.ts
+++ b/src/modules/transcript_chunk/transcript_chunk.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
@@ -36,38 +37,31 @@ export class TranscriptChunkController {
 
   @Get()
   @ApiOkResponse({ type: [TranscriptChunk] })
-  findAllChunks(): Promise<ITranscriptChunk[]> {
+  findAll(@Query('transcriptId') transcriptId?: string): Promise<ITranscriptChunk[]> {
+    if (transcriptId) {
+      return this.chunkService.findAll(transcriptId);
+    }
     return this.chunkService.findAllChunks();
   }
 
-  @Get(':transcriptId/chunk')
-  @ApiOkResponse({ type: [TranscriptChunk] })
-  findAll(@Param('transcriptId') transcriptId: string): Promise<ITranscriptChunk[]> {
-    return this.chunkService.findAll(transcriptId);
-  }
-
-  @Get(':transcriptId/chunk/:id')
+  @Get(':id')
   @ApiOkResponse({ type: TranscriptChunk })
   @ApiNotFoundResponse({ description: 'Transcript chunk not found' })
-  findOne(
-    @Param('transcriptId') transcriptId: string,
-    @Param('id') id: string,
-  ): Promise<ITranscriptChunk> {
+  findOne(@Param('id') id: string): Promise<ITranscriptChunk> {
     return this.chunkService.findOne(id);
   }
 
-  @Patch(':transcriptId/chunk/:id')
+  @Patch(':id')
   @ApiOkResponse({ type: TranscriptChunk })
   @ApiNotFoundResponse({ description: 'Transcript chunk not found' })
   update(
-    @Param('transcriptId') transcriptId: string,
     @Param('id') id: string,
     @Body() dto: UpdateTranscriptChunkDto,
   ): Promise<ITranscriptChunk> {
     return this.chunkService.update(id, dto);
   }
 
-  @Patch('chunk/:id/sanitized')
+  @Patch(':id/sanitized')
   @ApiOkResponse({ type: TranscriptChunk })
   @ApiNotFoundResponse({ description: 'Transcript chunk not found' })
   sanitizedUpdate(
@@ -77,7 +71,7 @@ export class TranscriptChunkController {
     return this.chunkService.update(id, dto);
   }
 
-  @Delete('chunk/:id')
+  @Delete(':id')
   @ApiOkResponse({ type: TranscriptChunk })
   @ApiNotFoundResponse({ description: 'Transcript chunk not found' })
   delete(@Param('id') id: string): Promise<ITranscriptChunk> {

--- a/src/modules/transcript_chunk/transcript_chunk.service.ts
+++ b/src/modules/transcript_chunk/transcript_chunk.service.ts
@@ -25,8 +25,16 @@ export class TranscriptChunkService {
     // Validate dto fields
     if (
       typeof dto.transcriptId !== 'string' ||
-      !(dto.startAt instanceof Date || typeof dto.startAt === 'string' || typeof dto.startAt === 'number') ||
-      !(dto.endAt instanceof Date || typeof dto.endAt === 'string' || typeof dto.endAt === 'number')
+      !(
+        dto.startAt instanceof Date ||
+        typeof dto.startAt === 'string' ||
+        typeof dto.startAt === 'number'
+      ) ||
+      !(
+        dto.endAt instanceof Date ||
+        typeof dto.endAt === 'string' ||
+        typeof dto.endAt === 'number'
+      )
     ) {
       throw new BadRequestException('Invalid input data');
     }
@@ -71,5 +79,4 @@ export class TranscriptChunkService {
   async deleteByTranscriptId(transcriptId: string): Promise<void> {
     await this.chunkModel.deleteMany({ transcriptId });
   }
-
 }

--- a/src/modules/transcript_chunk/transcript_chunk.service.ts
+++ b/src/modules/transcript_chunk/transcript_chunk.service.ts
@@ -13,6 +13,7 @@ import {
   TranscriptChunkDocument,
 } from './schema/transcript_chunk.schema';
 import { sanitizedUpdate } from './utils/sanitized-update';
+import { ITranscriptChunk } from '@/common/interfaces/transcript_chuck';
 
 @Injectable()
 export class TranscriptChunkService {
@@ -21,7 +22,7 @@ export class TranscriptChunkService {
     private readonly chunkModel: Model<TranscriptChunkDocument>,
   ) {}
 
-  async create(dto: CreateTranscriptChunkDto): Promise<TranscriptChunk> {
+  async create(dto: CreateTranscriptChunkDto): Promise<ITranscriptChunk> {
     // Validate dto fields
     if (
       typeof dto.transcriptId !== 'string' ||
@@ -53,11 +54,15 @@ export class TranscriptChunkService {
     return this.chunkModel.create(dto);
   }
 
-  async findAll(transcriptId: string): Promise<TranscriptChunk[]> {
+  async findAll(transcriptId: string): Promise<ITranscriptChunk[]> {
     return this.chunkModel.find({ transcriptId }).sort({ startAt: 1 }).exec();
   }
 
-  async findOne(id: string): Promise<TranscriptChunk> {
+  async findAllChunks(): Promise<ITranscriptChunk[]> {
+    return this.chunkModel.find().exec();
+  }
+
+  async findOne(id: string): Promise<ITranscriptChunk> {
     const chunk = await this.chunkModel.findById(id);
     if (!chunk) throw new NotFoundException('Transcript chunk not found');
     return chunk;
@@ -66,11 +71,11 @@ export class TranscriptChunkService {
   async update(
     id: string,
     dto: UpdateTranscriptChunkDto,
-  ): Promise<TranscriptChunk> {
+  ): Promise<ITranscriptChunk> {
     return sanitizedUpdate(this.chunkModel, id, dto);
   }
 
-  async delete(id: string): Promise<TranscriptChunk> {
+  async delete(id: string): Promise<ITranscriptChunk> {
     const deleted = await this.chunkModel.findByIdAndDelete(id);
     if (!deleted) throw new NotFoundException('Transcript chunk not found');
     return deleted;

--- a/src/modules/transcript_chunk/utils/sanitized-update.ts
+++ b/src/modules/transcript_chunk/utils/sanitized-update.ts
@@ -1,5 +1,6 @@
-import { NotFoundException, BadRequestException } from '@nestjs/common';
-import { Types, Model } from 'mongoose';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import type { Model } from 'mongoose';
+import { Types } from 'mongoose';
 
 import type { UpdateTranscriptChunkDto } from '../dto/update-transcript-chunk.dto';
 import type { TranscriptChunkDocument } from '../schema/transcript_chunk.schema';
@@ -20,9 +21,20 @@ export async function sanitizedUpdate(
   // Only allow updating specific fields
   const sanitizedData: Partial<UpdateTranscriptChunkDto> = {};
   if (typeof dto.text === 'string') sanitizedData.text = dto.text;
-  if (dto.speakerType === 'AI' || dto.speakerType === 'User') sanitizedData.speakerType = dto.speakerType;
-  if (dto.startAt instanceof Date || typeof dto.startAt === 'string' || typeof dto.startAt === 'number') sanitizedData.startAt = new Date(dto.startAt);
-  if (dto.endAt instanceof Date || typeof dto.endAt === 'string' || typeof dto.endAt === 'number') sanitizedData.endAt = new Date(dto.endAt);
+  if (dto.speakerType === 'AI' || dto.speakerType === 'User')
+    sanitizedData.speakerType = dto.speakerType;
+  if (
+    dto.startAt instanceof Date ||
+    typeof dto.startAt === 'string' ||
+    typeof dto.startAt === 'number'
+  )
+    sanitizedData.startAt = new Date(dto.startAt);
+  if (
+    dto.endAt instanceof Date ||
+    typeof dto.endAt === 'string' ||
+    typeof dto.endAt === 'number'
+  )
+    sanitizedData.endAt = new Date(dto.endAt);
 
   const updated = await chunkModel.findByIdAndUpdate(id, sanitizedData, {
     new: true,

--- a/test/transcript/transcript.e2e.test.ts
+++ b/test/transcript/transcript.e2e.test.ts
@@ -38,7 +38,7 @@ describe('Transcript (e2e)', () => {
 
   it('should create a Transcript', async () => {
     const res = await request(app.getHttpServer())
-      .post('/transcripts')
+      .post('/transcript')
       .send({
         calllogid: calllogId,
         summary: 'Test summary',
@@ -48,9 +48,20 @@ describe('Transcript (e2e)', () => {
     transcriptId = res.body._id;
   });
 
+  it('should get all Transcripts', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/transcript');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body[0]._id).toBeDefined();
+    expect(res.body[0].calllogid).toBeDefined();
+    expect(res.body[0].summary).toBeDefined();
+  });
+
   it('should get the created Transcript by calllogId', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcripts/calllog/${calllogId}`);
+      .get(`/transcript/calllog/${calllogId}`);
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBeGreaterThan(0);
@@ -60,7 +71,7 @@ describe('Transcript (e2e)', () => {
 
   it('should update the Transcript', async () => {
     const res = await request(app.getHttpServer())
-      .patch(`/transcripts/${transcriptId}`)
+      .patch(`/transcript/${transcriptId}`)
       .send({ summary: 'Updated summary' });
     expect(res.status).toBe(200);
     expect(res.body.summary).toBe('Updated summary');
@@ -69,14 +80,14 @@ describe('Transcript (e2e)', () => {
 
   it('should delete the Transcript', async () => {
     const res = await request(app.getHttpServer())
-      .delete(`/transcripts/${transcriptId}`);
+      .delete(`/transcript/${transcriptId}`);
     expect(res.status).toBe(200);
     expect(res.body._id).toBe(transcriptId);
   });
 
   it('should return empty array after deleting the Transcript', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcripts/calllog/${calllogId}`);
+      .get(`/transcript/calllog/${calllogId}`);
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBe(0);

--- a/test/transcript_chunk/transcript_chunk.e2e.test.ts
+++ b/test/transcript_chunk/transcript_chunk.e2e.test.ts
@@ -82,7 +82,7 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should get all chunks for a transcript', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcript-chunk/${transcriptId}/chunk`);
+      .get(`/transcript-chunk?transcriptId=${transcriptId}`);
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBe(1);
@@ -91,7 +91,7 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should update a chunk', async () => {
     const res = await request(app.getHttpServer())
-      .patch(`/transcript-chunk/${transcriptId}/chunk/${chunkId}`)
+      .patch(`/transcript-chunk/${chunkId}`)
       .send({ text: 'Updated text' });
     expect(res.status).toBe(200);
     expect(res.body.text).toBe('Updated text');
@@ -99,21 +99,21 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should get a single chunk', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcript-chunk/${transcriptId}/chunk/${chunkId}`);
+      .get(`/transcript-chunk/${chunkId}`);
     expect(res.status).toBe(200);
     expect(res.body._id).toBe(chunkId);
   });
 
   it('should delete a chunk', async () => {
     const res = await request(app.getHttpServer())
-      .delete(`/transcript-chunk/chunk/${chunkId}`);
+      .delete(`/transcript-chunk/${chunkId}`);
     expect(res.status).toBe(200);
     expect(res.body._id).toBe(chunkId);
   });
 
   it('should return empty array after deleting the chunk', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcript-chunk/${transcriptId}/chunk`);
+      .get(`/transcript-chunk?transcriptId=${transcriptId}`);
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBe(0);

--- a/test/transcript_chunk/transcript_chunk.e2e.test.ts
+++ b/test/transcript_chunk/transcript_chunk.e2e.test.ts
@@ -57,6 +57,15 @@ describe('TranscriptChunk (e2e)', () => {
     chunkId = res.body._id;
   });
 
+  it('should get all chunks (global)', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/transcript-chunk');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body.some((c: any) => c._id === chunkId)).toBe(true);
+  });
+
   it('should not allow overlapping time ranges', async () => {
     const res = await request(app.getHttpServer())
       .post('/transcript-chunk')

--- a/test/transcript_chunk/transcript_chunk.e2e.test.ts
+++ b/test/transcript_chunk/transcript_chunk.e2e.test.ts
@@ -30,7 +30,7 @@ describe('TranscriptChunk (e2e)', () => {
     calllogId = calllogRes.body._id;
 
     const transcriptRes = await request(app.getHttpServer())
-      .post('/transcripts')
+      .post('/transcript')
       .send({
         calllogid: calllogId,
         summary: 'Test summary',
@@ -44,7 +44,7 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should create a TranscriptChunk', async () => {
     const res = await request(app.getHttpServer())
-      .post('/transcript-chunks')
+      .post('/transcript-chunk')
       .send({
         transcriptId,
         speakerType: 'AI',
@@ -59,7 +59,7 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should not allow overlapping time ranges', async () => {
     const res = await request(app.getHttpServer())
-      .post('/transcript-chunks')
+      .post('/transcript-chunk')
       .send({
         transcriptId,
         speakerType: 'User',
@@ -73,7 +73,7 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should get all chunks for a transcript', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcript-chunks/${transcriptId}/chunks`);
+      .get(`/transcript-chunk/${transcriptId}/chunk`);
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBe(1);
@@ -82,7 +82,7 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should update a chunk', async () => {
     const res = await request(app.getHttpServer())
-      .patch(`/transcript-chunks/${transcriptId}/chunks/${chunkId}`)
+      .patch(`/transcript-chunk/${transcriptId}/chunk/${chunkId}`)
       .send({ text: 'Updated text' });
     expect(res.status).toBe(200);
     expect(res.body.text).toBe('Updated text');
@@ -90,21 +90,21 @@ describe('TranscriptChunk (e2e)', () => {
 
   it('should get a single chunk', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcript-chunks/${transcriptId}/chunks/${chunkId}`);
+      .get(`/transcript-chunk/${transcriptId}/chunk/${chunkId}`);
     expect(res.status).toBe(200);
     expect(res.body._id).toBe(chunkId);
   });
 
   it('should delete a chunk', async () => {
     const res = await request(app.getHttpServer())
-      .delete(`/transcript-chunks/chunk/${chunkId}`);
+      .delete(`/transcript-chunk/chunk/${chunkId}`);
     expect(res.status).toBe(200);
     expect(res.body._id).toBe(chunkId);
   });
 
   it('should return empty array after deleting the chunk', async () => {
     const res = await request(app.getHttpServer())
-      .get(`/transcript-chunks/${transcriptId}/chunks`);
+      .get(`/transcript-chunk/${transcriptId}/chunk`);
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBe(0);


### PR DESCRIPTION
This PR introduces the following changes:

1. Added TypeScript interfaces for both **transcript** and **transcript_chunk** to ensure type safety and clearer data structures across the codebase.
2. Refactored API endpoints for transcript and transcript_chunk to follow RESTful best practices:
  - Endpoints now use resource-oriented, consistent, and intuitive URL patterns.
  - Operations on single resources (e.g., update, delete, get) now use only the resource ID, reducing redundancy.
  - List queries (e.g., get all chunks for a transcript) now use query parameters instead of nested routes.
  - Updated related e2e tests and documentation to match the new API design.