### PR TITLE
Bugfix/log in user id return

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -71,9 +71,14 @@ export class AuthController {
     @Body() loginDto: LoginDto,
   ): Promise<{ user: UserResponseDto; token: string }> {
     const { user, token } = await this.authService.login(loginDto);
-    const safeUser = plainToInstance(UserResponseDto, user, {
-      excludeExtraneousValues: true,
-    });
+
+    const safeUser: UserResponseDto = {
+      _id: String(user._id),
+      email: String(user.email),
+      firstName: user.firstName ? String(user.firstName) : undefined,
+      lastName: user.lastName ? String(user.lastName) : undefined,
+      role: user.role,
+    };
     return { user: safeUser, token };
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -50,7 +50,7 @@ export class AuthService {
     if (!isPasswordValid) {
       throw new UnauthorizedException('Username or Password Not Match');
     }
-    const user = foundUser.toObject() as User;
+    const user = foundUser.toObject({ virtuals: false });
     const token = this.jwtService.sign({
       sub: user._id,
       email: user.email,


### PR DESCRIPTION
**问题原因**
Mongoose 的 toObject() 方法默认会生成一个虚拟字段 id（字符串类型），它和 _id 不同。
使用 class-transformer 的 @Expose({ name: '_id' }) userId 时，如果 user 对象中同时存在 id 和 _id 字段，class-transformer 可能会优先用 id 字段的值，导致 userId 映射错误。
即使在 service 层删除了 user.id 字段，plainToInstance 依然可能因类型推断或对象结构问题导致 userId 不一致。


**解决方案**
在 service 层 toObject 时明确加 { virtuals: false }，防止生成虚拟字段 id。
在 controller 层不再依赖 plainToInstance 自动映射，而是手动构造返回对象，确保 userId 和 id 都直接取自数据库的 _id 字段，类型安全且可控。